### PR TITLE
Add API requester interceptors and update to Java 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Sample z/OS Connect Enterprise Edition (EE) Interceptors which demonstrates how 
 
 ### Building
 
-This example project shows how to build a WebSphere Liberty Profile OSGi extension that can be deployed to a Liberty Profile server. This extension contains two sample z/OS Connect EE Interceptors.  If you wish to create z/OS Connect EE Interceptors of your own, then this project may be used as a base.
+This example project shows how to build a WebSphere Liberty Profile OSGi extension that can be deployed to a Liberty Profile server. This extension contains four sample z/OS Connect EE Interceptors.  If you wish to create z/OS Connect EE Interceptors of your own, then this project may be used as a base.
 
 This project contains an Eclipse project which can be imported to your Eclipse installation.  The Eclipse installation must have the IBM WebSphere Application Server V9.x Developer Tools installed.
 
@@ -20,11 +20,15 @@ The important files in the `com.ibm.crshnburn.zosconnect.interceptor` project ar
 
 * src/com/ibm/crshnburn/zosconnect/interceptor/Activator.java - An OSGi Bundle Activator
 * src/com/ibm/crshnburn/zosconnect/interceptor/AllPointsInterceptorSample.java - An Interceptor, ServiceProviderInterceptor, and EarlyFailureInterceptor implementation.
+* src/com/ibm/crshnburn/zosconnect/interceptor/AllPointsInterceptorRequesterSample.java - An Interceptor, InterceptorRequester, EndpointInterceptor, and EarlyFailureInterceptorRequester implementation.
 * src/com/ibm/crshnburn/zosconnect/interceptor/SimpleInterceptorImpl.java - An Interceptor implementation.
+* src/com/ibm/crshnburn/zosconnect/interceptor/SimpleInterceptorRequesterImpl.java - An InterceptorRequester implementation.
 * BundleContent/Meta-INF/MANIFEST.MF - The `com.ibm.crshnburn.zosconnect.interceptor` Bundle manifest that describes the bundle.
 * BundleContent/OSGI-INF/metatype/metatype.xml - Describes the server.xml configuration element detail.
-* BundleContent/OSGI-INF/com.ibm.crshnburn.zosconnect.allpointsinterceptor.xml - Describes  the implementation class and services of the AllPointsInterceptorSample class
-* BundleContent/OSGI-INF/com.ibm.crshnburn.zosconnect.interceptor.xml - Describes  the implementation class and services of the SimpleInterceptorImpl class
+* BundleContent/OSGI-INF/com.ibm.crshnburn.zosconnect.allpointsinterceptor.xml - Describes the implementation class and services of the AllPointsInterceptorSample class
+* BundleContent/OSGI-INF/com.ibm.crshnburn.zosconnect.allpointsinterceptor.requester.xml - Describes the implementation class and services of the AllPointsInterceptorRequesterSample class
+* BundleContent/OSGI-INF/com.ibm.crshnburn.zosconnect.interceptor.xml - Describes the implementation class and services of the SimpleInterceptorImpl class
+* BundleContent/OSGI-INF/com.ibm.crshnburn.zosconnect.interceptor.requester.xml - Describes the implementation class and services of the SimpleInterceptorRequesterImpl class
 
 The important files in the `com.ibm.crshnburn.zosconnect.feature` project are:
 
@@ -34,7 +38,7 @@ The Java code will build automatically and when you are ready to create a Libert
 
 ### Installing
 
-* Install the feature into your z/OS Connect EE environment `wlp/bin/installUtility install sample-interceptor.esa`.  The `wlp` directory is relative the the z/OS Connect EE installation directory.
+* Install the feature into your z/OS Connect EE environment `wlp/bin/installUtility install sample-interceptor.esa`.  The `wlp` directory is relative to the z/OS Connect EE installation directory.
 
 ### Configuring
 
@@ -42,20 +46,22 @@ The Java code will build automatically and when you are ready to create a Libert
 ```
 <feature>usr:sampleinterceptor-1.0</feature>
 ```
-* Create an interceptor definition for the two sample Interceptors:
+* Create an interceptor definition for the four sample Interceptors:
 
 ```
 <usr_simpleInterceptor id="simpleInterceptor" sequence="1"/>
 <usr_allPointsInterceptor id="allPointsInterceptor" sequence="2"/>
+<usr_simpleInterceptorRequester id="simpleInterceptorRequester" sequence="1"/>
+<usr_allPointsInterceptorRequester id="allPointsInterceptorRequester" sequence="2"/>
 <zosconnect_zosConnectInterceptors id="interceptorList"
-           interceptorRef="simpleInterceptor,allPointsInterceptor"/>
+           interceptorRef="simpleInterceptor,allPointsInterceptor,simpleInterceptorRequester,allPointsInterceptorRequester"/>
 ```
-* Add the interceptors to the required global, API or service interceptor manager.  See z/OS Connect EE configuration documentation for details.
+* Add the interceptors at the required global, API, service or API requester level.  See z/OS Connect EE configuration documentation for details.
 
 
 ### Notice
 
-&copy; Copyright IBM Corporation 2015, 2019
+&copy; Copyright IBM Corporation 2015, 2020
 
 ### License
 ```

--- a/src/com.ibm.crshnburn.zosconnect.interceptor/.classpath
+++ b/src/com.ibm.crshnburn.zosconnect.interceptor/.classpath
@@ -7,12 +7,11 @@
 			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/ibm-java-x86_64-80">
+	<classpathentry kind="con" path="org.eclipse.jst.server.core.container/com.ibm.ws.st.core.runtimeClasspathProvider/Liberty Runtime"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/jdk">
 		<attributes>
 			<attribute name="owner.project.facets" value="java"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="/com.ibm.ws.zos.connect/build/lib/com.ibm.zosconnect.spi.jar"/>
-	<classpathentry kind="con" path="org.eclipse.jst.server.core.container/com.ibm.ws.st.core.runtimeClasspathProvider/Liberty Runtime"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/src/com.ibm.crshnburn.zosconnect.interceptor/.settings/org.eclipse.jdt.core.prefs
+++ b/src/com.ibm.crshnburn.zosconnect.interceptor/.settings/org.eclipse.jdt.core.prefs
@@ -1,13 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
-org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=1.7
-org.eclipse.jdt.core.compiler.debug.lineNumber=generate
-org.eclipse.jdt.core.compiler.debug.localVariable=generate
-org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.processAnnotations=enabled
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=1.8

--- a/src/com.ibm.crshnburn.zosconnect.interceptor/.settings/org.eclipse.wst.common.project.facet.core.xml
+++ b/src/com.ibm.crshnburn.zosconnect.interceptor/.settings/org.eclipse.wst.common.project.facet.core.xml
@@ -4,5 +4,5 @@
   <fixed facet="osgi.bundle"/>
   <fixed facet="java"/>
   <installed facet="osgi.bundle" version="1.0"/>
-  <installed facet="java" version="1.7"/>
+  <installed facet="java" version="1.8"/>
 </faceted-project>

--- a/src/com.ibm.crshnburn.zosconnect.interceptor/BundleContent/META-INF/MANIFEST.MF
+++ b/src/com.ibm.crshnburn.zosconnect.interceptor/BundleContent/META-INF/MANIFEST.MF
@@ -3,12 +3,15 @@ Bundle-ManifestVersion: 2
 Bundle-Name: com.ibm.crshnburn.zosconnect.interceptor
 Bundle-SymbolicName: com.ibm.crshnburn.zosconnect.interceptor
 Bundle-Version: 1.0.0.0
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: com.ibm.zosconnect.spi,
  org.osgi.framework,
  org.osgi.service.component
 Service-Component: OSGI-INF/com.ibm.crshnburn.zosconnect.interceptor.xml,
- OSGI-INF/com.ibm.crshnburn.zosconnect.allpointsinterceptor.xml
+ OSGI-INF/com.ibm.crshnburn.zosconnect.allpointsinterceptor.xml,
+ OSGI-INF/com.ibm.crshnburn.zosconnect.interceptor.requester.xml,
+ OSGI-INF/com.ibm.crshnburn.zosconnect.allpointsinterceptor.requester.xml,
 Export-Package: com.ibm.crshnburn.zosconnect.interceptor
 Bundle-Activator: com.ibm.crshnburn.zosconnect.interceptor.Activator
+Bundle-ActivationPolicy: lazy
 

--- a/src/com.ibm.crshnburn.zosconnect.interceptor/BundleContent/OSGI-INF/com.ibm.crshnburn.zosconnect.allpointsinterceptor.requester.xml
+++ b/src/com.ibm.crshnburn.zosconnect.interceptor/BundleContent/OSGI-INF/com.ibm.crshnburn.zosconnect.allpointsinterceptor.requester.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component xmlns="http://www.osgi.org/xmlns/scr/v1.2.0" activate="activate" configuration-policy="require" deactivate="deactivate" modified="modified" name="allPointsInterceptorRequester" configuration-pid="com.ibm.crshnburn.zosconnect.allpointsinterceptor.requester">
+  <implementation class="com.ibm.crshnburn.zosconnect.interceptor.AllPointsInterceptorRequesterSample"/>
+  <service>
+     <provide interface="com.ibm.zosconnect.spi.Interceptor"/>
+  </service>
+  <property name="service.vendor" type="String" value="IBM"/>
+  <property name="service.product" type="String" value="All Points Sample Interceptor Requester"/>
+  <property name="service.ranking" type="String" value="1"/>
+</component>

--- a/src/com.ibm.crshnburn.zosconnect.interceptor/BundleContent/OSGI-INF/com.ibm.crshnburn.zosconnect.allpointsinterceptor.xml
+++ b/src/com.ibm.crshnburn.zosconnect.interceptor/BundleContent/OSGI-INF/com.ibm.crshnburn.zosconnect.allpointsinterceptor.xml
@@ -3,8 +3,6 @@
   <implementation class="com.ibm.crshnburn.zosconnect.interceptor.AllPointsInterceptorSample"/>
   <service>
      <provide interface="com.ibm.zosconnect.spi.Interceptor"/>
-     <provide interface="com.ibm.zosconnect.spi.ServiceProviderInterceptor"/>
-     <provide interface="com.ibm.zosconnect.spi.EarlyFailureInterceptor"/>
   </service>
   <property name="service.vendor" type="String" value="IBM"/>
   <property name="service.product" type="String" value="All Points Sample Interceptor"/>

--- a/src/com.ibm.crshnburn.zosconnect.interceptor/BundleContent/OSGI-INF/com.ibm.crshnburn.zosconnect.interceptor.requester.xml
+++ b/src/com.ibm.crshnburn.zosconnect.interceptor/BundleContent/OSGI-INF/com.ibm.crshnburn.zosconnect.interceptor.requester.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component xmlns="http://www.osgi.org/xmlns/scr/v1.2.0" activate="activate" configuration-policy="require" deactivate="deactivate" modified="modified" name="simpleInterceptorRequester" configuration-pid="com.ibm.crshnburn.zosconnect.interceptor.requester">
+  <implementation class="com.ibm.crshnburn.zosconnect.interceptor.SimpleInterceptorRequesterImpl"/>
+  <service>
+     <provide interface="com.ibm.zosconnect.spi.Interceptor"/>
+  </service>
+  <property name="service.vendor" type="String" value="IBM"/>
+  <property name="service.product" type="String" value="Sample Interceptor Requester"/>
+  <property name="service.ranking" type="String" value="1"/>
+</component>

--- a/src/com.ibm.crshnburn.zosconnect.interceptor/BundleContent/OSGI-INF/metatype/metatype.xml
+++ b/src/com.ibm.crshnburn.zosconnect.interceptor/BundleContent/OSGI-INF/metatype/metatype.xml
@@ -3,7 +3,7 @@
                    xmlns:ibm="http://www.ibm.com/xmlns/appservers/osgi/metatype/v1.0.0"
                    localization="OSGI-INF/l10n/metatype">
 
-    <OCD id="com.ibm.crshnburn.zosconnect.interceptor" ibm:alias="simpleInterceptor" name="simpleInterceptor" description="Sample z/OS Connect Interceptor" ibm:objectClass="com.ibm.zosconnect.interceptorType">
+    <OCD id="com.ibm.crshnburn.zosconnect.interceptor" ibm:alias="simpleInterceptor" name="simpleInterceptor" description="Sample z/OS Connect EE Interceptor" ibm:objectClass="com.ibm.zosconnect.interceptorType">
         <AD id="sequence" required="false" type="Integer" default="0" min="0" max="2147483647" name="Sequence" description="The sequence in which this interceptor should be processed with respect to other configured interceptors"/>
     </OCD>
 
@@ -11,11 +11,27 @@
         <Object ocdref="com.ibm.crshnburn.zosconnect.interceptor" />
     </Designate>
 
-    <OCD id="com.ibm.crshnburn.zosconnect.allpointsinterceptor" ibm:alias="allPointsInterceptor" name="allPointsInterceptor" description="Sample All Points z/OS Connect Interceptor" ibm:objectClass="com.ibm.zosconnect.interceptorType">
+    <OCD id="com.ibm.crshnburn.zosconnect.allpointsinterceptor" ibm:alias="allPointsInterceptor" name="allPointsInterceptor" description="Sample All Points z/OS Connect EE Interceptor" ibm:objectClass="com.ibm.zosconnect.interceptorType">
         <AD id="sequence" required="false" type="Integer" default="0" min="0" max="2147483647" name="Sequence" description="The sequence in which this interceptor should be processed with respect to other configured interceptors"/>
     </OCD>
 
     <Designate factoryPid="com.ibm.crshnburn.zosconnect.allpointsinterceptor">
         <Object ocdref="com.ibm.crshnburn.zosconnect.allpointsinterceptor" />
+    </Designate>
+    
+    <OCD id="com.ibm.crshnburn.zosconnect.interceptor.requester" ibm:alias="simpleInterceptorRequester" name="simpleInterceptorRequester" description="Sample z/OS Connect EE Interceptor for API requester" ibm:objectClass="com.ibm.zosconnect.interceptorType">
+        <AD id="sequence" required="false" type="Integer" default="0" min="0" max="2147483647" name="Sequence" description="The sequence in which this interceptor should be processed with respect to other configured interceptors"/>
+    </OCD>
+    
+    <Designate factoryPid="com.ibm.crshnburn.zosconnect.interceptor.requester">
+        <Object ocdref="com.ibm.crshnburn.zosconnect.interceptor.requester" />
+    </Designate>
+    
+    <OCD id="com.ibm.crshnburn.zosconnect.allpointsinterceptor.requester" ibm:alias="allPointsInterceptorRequester" name="allPointsInterceptorRequester" description="Sample All Points z/OS Connect EE Interceptor for API requester" ibm:objectClass="com.ibm.zosconnect.interceptorType">
+        <AD id="sequence" required="false" type="Integer" default="0" min="0" max="2147483647" name="Sequence" description="The sequence in which this interceptor should be processed with respect to other configured interceptors"/>
+    </OCD>
+
+    <Designate factoryPid="com.ibm.crshnburn.zosconnect.allpointsinterceptor.requester">
+        <Object ocdref="com.ibm.crshnburn.zosconnect.allpointsinterceptor.requester" />
     </Designate>
 </metatype:MetaData>

--- a/src/com.ibm.crshnburn.zosconnect.interceptor/src/com/ibm/crshnburn/zosconnect/interceptor/AllPointsInterceptorRequesterSample.java
+++ b/src/com.ibm.crshnburn.zosconnect.interceptor/src/com/ibm/crshnburn/zosconnect/interceptor/AllPointsInterceptorRequesterSample.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright IBM Corporation 2020
+ *
+ * LICENSE: Apache License
+ *          Version 2.0, January 2004
+ *          http://www.apache.org/licenses/
+ *
+ * The following code is sample code created by IBM Corporation.
+ * This sample code is not part of any standard IBM product and
+ * is provided to you solely for the purpose of assisting you in
+ * the development of your applications.  The code is provided
+ * 'as is', without warranty or condition of any kind.  IBM shall
+ * not be liable for any damages arising out of your use of the
+ * sample code, even if IBM has been advised of the possibility
+ * of such damages.
+ */
+package com.ibm.crshnburn.zosconnect.interceptor;
+
+import java.util.Map;
+
+import org.osgi.service.component.ComponentContext;
+
+import com.ibm.zosconnect.spi.Data;
+import com.ibm.zosconnect.spi.DataRequester;
+import com.ibm.zosconnect.spi.EarlyFailureInterceptorRequester;
+import com.ibm.zosconnect.spi.EndpointInterceptor;
+import com.ibm.zosconnect.spi.HttpZosConnectRequest;
+import com.ibm.zosconnect.spi.InterceptorException;
+
+/**
+ * The AllPointsInterceptorRequesterSample class is an example of an Interceptor that implements the Interceptor,
+ * InterceptorRequester, EndpointInterceptor, and EarlyFailureInterceptorRequester interfaces. 
+ *  
+ * Both the EndpointInterceptor and EarlyFailureInterceptorRequester interfaces extend the InterceptorRequester 
+ * interface, which in turn extends the Interceptor interface, so all methods of those interfaces are implemented as well.
+ *
+ * Note, it is possible that an Interceptor can be configured so that it is invoked more than once for the same 
+ * request, although this is unlikely to be intended behaviour.
+ *
+ * The points at which this sample Interceptor methods are invoked in an API requester flow are illustrated here:
+ * https://www.ibm.com/support/knowledgecenter/SS4SVW_3.0.0/extending/create_monitoring_interceptor.html and detailed in
+ * the steps below.
+ *
+ * The API requester request flow:
+ * 1.  A request is received by z/OS Connect EE from the communication stub program BAQCSTUB.
+ * 2.  Authentication and request format checks are made.
+ * 3.  If the request fails any checks in step 2 and there is a global Interceptor registered that implements the
+ *     EarlyFailureInterceptorRequester interface, its earlyFailureRequester method is called and the request
+ *     terminates. 
+ * 4.  The request has now passed the early checks, the request can still fail, but it is now not an early failure
+ *     and earlyFailureRequester will not now be called.
+ * 5.  If there is an Interceptor registered at either the global or API requester level that implements the
+ *     InterceptorRequester interface, its preInvokeRequester method is called. 
+ * 6.  Request data mapping is performed.
+ * 7.  If there is an Interceptor registered at either the global or API requester level that implements the 
+ *     EndpointInterceptor interface, its preEndpointInvoke method is called.
+ * 8.  The API request is sent to the endpoint.
+ * 9.  When the endpoint response is received, the EndpointInterceptor postEndpointInvoke method is called, if the 
+ *     corresponding preEndpointInvoke method was called.
+ * 10. Response data mapping is performed.
+ * 11. The InterceptorRequester postInvokeRequester method is called if the corresponding preInvokeRequester method
+ *     was called.
+ * 12. z/OS Connect EE returns the response to the BAQCSTUB program.
+ *
+ * @author IBM
+ */
+public class AllPointsInterceptorRequesterSample implements EndpointInterceptor, EarlyFailureInterceptorRequester {
+
+    /**
+     * The registered sequence number of this Interceptor which determines the order
+     * in which the Interceptor is called in relation to other Interceptors.
+     */
+    private int sequence;
+
+    /**
+     * Activates the Interceptor.
+     *
+     * Trace the activation and retrieve the Interceptor's sequence number from
+     * the Interceptor configuration element in server.xml.
+     *
+     * @param context
+     * @param properties
+     */
+    protected void activate(ComponentContext context, Map<String, Object> properties) {
+
+        System.out.println(getName() + " activated");
+        if (properties.containsKey(CFG_AD_SEQUENCE_ALIAS)) {
+            sequence = (Integer) properties.get(CFG_AD_SEQUENCE_ALIAS);
+        }
+    }
+
+    /**
+     * Deactivates the Interceptor.
+     *
+     * The Interceptor will no longer receive events.
+     *
+     * @param context
+     */
+    protected void deactivate(ComponentContext context) {
+        System.out.println(getName() + " deactivated");
+    }
+
+    /**
+     * Called to signal that the Interceptor's configuration element may have changed in server.xml.
+     *
+     * Trace the activation and retrieve the Interceptor's sequence number from
+     * the Interceptor's configuration element in server.xml.
+     *
+     * @param context
+     * @param properties
+     */
+    protected void modified(Map<String, Object> properties) {
+
+        System.out.println(getName() + " modified");
+        if (properties.containsKey(CFG_AD_SEQUENCE_ALIAS)) {
+            sequence = (Integer) properties.get(CFG_AD_SEQUENCE_ALIAS);
+        }
+    }
+
+    /**
+     * Returns this Interceptor's configured sequence number so z/OS Connect EE can 
+     * determine the sequence in which to call Interceptors.
+     */
+    @Override
+    public int getSequence() {
+        return sequence;
+    }
+
+    /**
+     * Returns this Interceptors name.
+     */
+    @Override
+    public String getName() {
+        return "zOSConnectAllPointsSampleInterceptorRequester";
+    }
+       
+	/**
+     * z/OS Connect EE calls the preInvokeRequester method after initial request checks.
+     *
+     * The Interceptor is given a request state map that can be used to store data, such as state data, between the 
+     * preInvokeRequester and the postInvokeRequester methods.
+     *
+     * The DataRequester object provides API requester specific data to the Interceptor.
+     * See com.ibm.zosconnect.spi.DataRequester javadoc for details.  As the API requester request flows through
+     * z/OS Connect EE more data is captured and stored in the DataRequester object.  
+     *
+     * In this example, the API requester name and version are obtained and logged.
+     * 
+     * @param requestStateMap
+     * @param data
+     */
+	@Override
+	public void preInvokeRequester(Map<Object, Object> requestStateMap, DataRequester data) {
+		System.out.println(getName() + " preInvokeRequester");
+		
+		System.out.println("Invoking the API requester " + data.getData(DataRequester.API_REQUESTER_NAME) + 
+				           " verion " + data.getData(DataRequester.API_REQUESTER_VERSION));
+		
+		System.out.println(getName() + " preInvokeRequester exit");
+	}
+
+    /**
+    *
+    * z/OS Connect EE calls the preEndpointInvoke method just before calling the endpoint.
+    *
+    * The Interceptor is given a request state map that can be used to store data, such as state data, between the 
+    * preEndpointInvoke, postEndpointInvoke and postInvokeRequester methods.
+    *
+    * The DataRequester object provides the API requester request specific data available to Interceptors.
+    * See com.ibm.zosconnect.spi.DataRequester javadoc for details.
+    *
+    * @param requestStateMap
+    * @param data
+    */
+	public void preEndpointInvoke(Map<Object, Object> requestStateMap, DataRequester data) {
+		System.out.println(getName() + " preEndpointInvoke");
+		
+		System.out.println("API requester target endpoint " + data.getData(DataRequester.ENDPOINT_HOST) +
+				           ":" + data.getData(DataRequester.ENDPOINT_PORT));
+		
+		System.out.println("API requester about to invoke method " + data.getData(DataRequester.ENDPOINT_METHOD) + 
+				           " for path " + data.getData(DataRequester.ENDPOINT_FULL_PATH));
+			
+		System.out.println(getName() + " preEndpointInvoke exit");
+	}
+	
+    /**
+     * z/OS Connect EE calls the postEndpointInvoke method once the call to the endpoint returns.
+     *
+     * The DataRequester object provides API requester specific data to the Interceptor.
+     * See com.ibm.zosconnect.spi.DataRequester javadoc for details.  
+     * 
+     * In this example, the request response code is obtained and logged.
+     *
+     * @param requestStateMap
+     * @param data
+     */
+	public void postEndpointInvoke(Map<Object, Object> requestStateMap, DataRequester data) {
+		System.out.println(getName() + " postEndpointInvoke");
+		
+		System.out.println("API requester was invoked and the endpoint returned " + data.getData(DataRequester.HTTP_RESPONSE_CODE));
+		
+		System.out.println(getName() + " postEndpointInvoke exit");
+	}
+	
+    /**
+     * z/OS Connect EE calls the postInvokeRequester method.
+     *
+     * The DataRequester object provides the API requester request specific data available to Interceptors.
+     * See com.ibm.zosconnect.spi.DataRequester javadoc for details.  As the API requester request flows through
+     * z/OS Connect EE more data elements are captured and stored in the DataRequester object.
+     *
+     * @param requestStateMap
+     * @param data
+     */
+	@Override
+	public void postInvokeRequester(Map<Object, Object> requestStateMap, DataRequester data) {
+		System.out.println(getName() + " postInvokeRequester");
+		
+		System.out.println("API requester returning to calling application with " + data.getData(DataRequester.REQUEST_STATUS_CODE));
+		
+		System.out.println(getName() + " postInvokeRequester exit");
+	}
+	
+	/** 
+	 * z/OS Connect EE calls the earlyFailureRequester method for a failing API requester request.
+     *
+     * The DataRequester object provides the API requester request specific data available to Interceptors.
+     * See com.ibm.zosconnect.spi.DataRequester javadoc for details.
+     *
+     * @param data
+	 */
+	@Override
+	public void earlyFailureRequester(DataRequester data) {
+		System.out.println(getName() + " earlyFailureRequester");
+
+        System.out.println("The request failed early, returning to application with " + data.getData(DataRequester.REQUEST_STATUS_CODE));
+
+        System.out.println(getName() + " earlyFailureRequester exit");	
+	}
+
+	/**
+     * This method is not called for API requester requests. It is called for API provider and all administration requests.
+     */
+	@Override
+	public void preInvoke(Map<Object, Object> arg0, HttpZosConnectRequest arg1, Data arg2) throws InterceptorException {
+		System.out.println(getName() + " preInvoke");
+		System.out.println(getName() + " preInvoke exit");
+	}
+	
+	/**
+     * This method is not called for API requester requests. It is called for API provider and all administration requests. 
+     */
+	@Override
+	public void postInvoke(Map<Object, Object> arg0, HttpZosConnectRequest arg1, Data arg2)
+			throws InterceptorException {
+		System.out.println(getName() + " postInvoke");
+		System.out.println(getName() + " postInvoke exit");
+	}
+}

--- a/src/com.ibm.crshnburn.zosconnect.interceptor/src/com/ibm/crshnburn/zosconnect/interceptor/AllPointsInterceptorSample.java
+++ b/src/com.ibm.crshnburn.zosconnect.interceptor/src/com/ibm/crshnburn/zosconnect/interceptor/AllPointsInterceptorSample.java
@@ -39,31 +39,31 @@ import com.ibm.zosconnect.spi.ServiceProviderInterceptor;
  * Connect EE, and again after the SoR response has been returned and z/OS Connect EE is about to return to the
  * caller. For simplification these points are known as P1, P2, P3, P4, and EarlyFailure.
  *
- * The flow of the API Provider request as it relates to the Interceptor framework is as follows.
+ * The flow of the API provider request as it relates to the Interceptor framework is as follows.
  *
  * 1.  A request is received by z/OS Connect EE.
  * 2.  The request is validated, e.g. Bad URL paths, authentication failures, bad JSON, etc.
  * 3.  Next, the requests Service and API information is extracted and matched to registered Services and APIs.
  * 4.  Should the request fail in the above processing the request is said to be an Early Failed request.
- * 5.  If there is an Interceptor registered with the Global Interceptor Manager that implements the
- *     EarlyFailureInterceptor interface its EarlyFail method will be invoked and the request terminates.
- * 6.  The API Provider request has now passed the early checks, the request can still fail, but it is now
- *     not an EarlyFailure and EarlyFail will now not be called.
- * 7.  If there is an Interceptor registered with either the Global, Service or API Interceptor Managers that
+ * 5.  If there is an Interceptor registered at the Global level that implements the
+ *     EarlyFailureInterceptor interface its earlyFailure method will be invoked and the request terminates.
+ * 6.  The API provider request has now passed the early checks, the request can still fail, but it is now
+ *     not an early failure and earlyFailure will now not be called.
+ * 7.  If there is an Interceptor registered at either the Global, Service or API levels that
  *     implements the Interceptor interface its preInvoke method will be invoked. This is point P1.
  * 8.  Request flow continues through z/OS Connect EE into the Service Provider which will call the
  *     System Of Record, e.g. CICS, IMS, DB2, etc.
- * 9.  If there is an Interceptor registered with either the Global, Service or API Interceptor Managers that
+ * 9.  If there is an Interceptor registered at either the Global, Service or API levels that
  *     implements the ServiceProviderInterceptor interface its preSorInvoke method will be invoked.
  *     This is point P2.  The SoR is then invoked.
  * 10. Once the SoR returns the ServiceProviderInterceptor is invoked on its postSorInvoke method.
  *     This is point P3.
- * 11. The API Provider response flow continues, any registered Interceptors with either the Global, Service or API
- *     Interceptor Managers that implements the Interceptor interface is invoked on its postInvoke method.
+ * 11. The API provider response flow continues, any registered Interceptors at either the Global, Service or API
+ *     levels that implements the Interceptor interface is invoked on its postInvoke method.
  *     This is point P4. Finally the response is sent by z/OS Connect EE.
  *
  * This Interceptor will be notified for all requests entering the z/OS Connect EE application, as a minimum either
- * on the Intercepts preInvoke method at P1, or on its EarlyFail method.  However, if the Liberty server is
+ * on the Interceptor's preInvoke method at P1, or on its earlyFailure method.  However, if the Liberty server is
  * configured to authenticate server users then these requests will not be seen if authentication fails.
  *
  * @author IBM
@@ -137,8 +137,7 @@ public class AllPointsInterceptorSample implements ServiceProviderInterceptor, E
     }
 
     /**
-     * Returns this Interceptors configured sequence number so the Interceptor Manager
-     * can determine the call sequence of Interceptors.
+     * Returns this Interceptors configured sequence number.
      */
     @Override
     public int getSequence() {
@@ -154,7 +153,7 @@ public class AllPointsInterceptorSample implements ServiceProviderInterceptor, E
     }
 
     /**
-     * Interceptor Manager calls preInvoke method at point P1.
+     * z/OS Connect EE calls preInvoke method at point P1.
      *
      * The Interceptor is given a request state map that can be used to store data entities between the preInvoke
      * at P1 and the postInvoke at P4, and also between P1, P2, P3, and P4.
@@ -163,7 +162,7 @@ public class AllPointsInterceptorSample implements ServiceProviderInterceptor, E
      * URL, HTTP Headers, etc. See com.ibm.zosconnect.spi.HttpZosConnectRequest javadoc for details.
      *
      * The Data object provides the request specific data available to Interceptors and Service Providers.
-     * See com.ibm.zosconnect.spi.Data javadoc for details.  As the API Provider request flows through
+     * See com.ibm.zosconnect.spi.Data javadoc for details.  As the API provider request flows through
      * z/OS Connect EE more data elements are captured and stored in the Data object.  As an example
      * Data.TIME_ZOS_CONNECT_ENTRY is available which contains the z/OS Store Clock Extended time held
      * in a byte array of length 16.
@@ -213,13 +212,13 @@ public class AllPointsInterceptorSample implements ServiceProviderInterceptor, E
 
     /**
      *
-     * Interceptor Manager calls preSorInvoke method at point P2 in the Service Provider.
+     * z/OS Connect EE calls preSorInvoke method at point P2 in the Service Provider.
      *
      * The Interceptor is given a request state map that can be used to store data entities between the
      * preSorInvoke at P2 and the postSorInvoke at P3, and also postInvoke at P4.
      *
      * The Data object provides the request specific data available to Interceptors and Service Providers.
-     * See com.ibm.zosconnect.spi.Data javadoc for details.  As the API Provider request flows through
+     * See com.ibm.zosconnect.spi.Data javadoc for details.  As the API provider request flows through
      * z/OS Connect EE more data elements are captured and stored in the Data object.
      *
      * Data elements that are available and relevant to point P2 are:
@@ -229,7 +228,7 @@ public class AllPointsInterceptorSample implements ServiceProviderInterceptor, E
      *  Data.SOR_RESOURCE
      *  Data.CORRELATOR
      *
-     * Note: There is no opportunity to cancel the API Provider request at this point with an
+     * Note: There is no opportunity to cancel the API provider request at this point with an
      *       InterceptorException.  Should a runtime exception be thrown by the method then the
      *       request will continue.
      *
@@ -257,10 +256,10 @@ public class AllPointsInterceptorSample implements ServiceProviderInterceptor, E
     }
 
     /**
-     * Interceptor Manager calls postSorInvoke method at point P3 in the Service Provider.
+     * z/OS Connect EE calls postSorInvoke method at point P3 in the Service Provider.
      *
      * The Data object provides the request specific data available to Interceptors and Service Providers.
-     * See com.ibm.zosconnect.spi.Data javadoc for details.  As the API Provider request flows through
+     * See com.ibm.zosconnect.spi.Data javadoc for details.  As the API provider request flows through
      * z/OS Connect EE more data elements are captured and stored in the Data object.
      *
      * New Data elements that are available and relevant to point P3 are:
@@ -292,10 +291,10 @@ public class AllPointsInterceptorSample implements ServiceProviderInterceptor, E
     }
 
     /**
-     * Interceptor Manager calls postInvoke method at point P4.
+     * z/OS Connect EE calls postInvoke method at point P4.
      *
      * The Data object provides the request specific data available to Interceptors and Service Providers.
-     * See com.ibm.zosconnect.spi.Data javadoc for details.  As the API Provider request flows through
+     * See com.ibm.zosconnect.spi.Data javadoc for details.  As the API provider request flows through
      * z/OS Connect EE more data elements are captured and stored in the Data object.
      *
      * New Data elements that are available and relevant to point P4 are:
@@ -336,10 +335,10 @@ public class AllPointsInterceptorSample implements ServiceProviderInterceptor, E
     }
 
     /**
-     * Interceptor Manager calls earlyFailure for a failing API Provider request.
+     * z/OS Connect EE calls earlyFailure for a failing API provider request.
      *
      * The Data object provides the request specific data available to Interceptors and Service Providers.
-     * See com.ibm.zosconnect.spi.Data javadoc for details.  As the API Provider request flows through
+     * See com.ibm.zosconnect.spi.Data javadoc for details.  As the API provider request flows through
      * z/OS Connect EE more data elements are captured and stored in the Data object.
      *
      * The minimum data available is as follows, however, if the request has progressed further

--- a/src/com.ibm.crshnburn.zosconnect.interceptor/src/com/ibm/crshnburn/zosconnect/interceptor/SimpleInterceptorImpl.java
+++ b/src/com.ibm.crshnburn.zosconnect.interceptor/src/com/ibm/crshnburn/zosconnect/interceptor/SimpleInterceptorImpl.java
@@ -39,27 +39,27 @@ import com.ibm.zosconnect.spi.InterceptorException;
  * caller. For simplification these points are known as P1, and P4.  See the  AllPointsInterceptorSample for
  * details of points P2 and P3.
  *
- * The flow of the API Provider request as it relates to the Interceptor framework is as follows.
+ * The flow of the API provider request as it relates to the Interceptor framework is as follows.
  *
  * 1.  A request is received by z/OS Connect EE.
  * 2.  The request is validated, e.g. Bad URL paths, authentication failures, bad JSON, etc.
  * 3.  Next, the requests Service and API information is extracted and matched to registered Services and APIs.
  * 4.  Should the request fail in the above processing the request is said to be an Early Failed request.
- * 5.  If there is an Interceptor registered with the Global Interceptor Manager that implements the
- *     EarlyFailureInterceptor interface its EarlyFail method will be invoked and the request terminates.
- * 6.  The API Provider request has now passed the early checks, the request can still fail, but it is now
- *     not an EarlyFailure and EarlyFail will now not be called.
- * 7.  If there is an Interceptor registered with either the Global, Service or API Interceptor Managers that
+ * 5.  If there is an Interceptor registered at the Global level that implements the
+ *     EarlyFailureInterceptor interface its earlyFailure method will be invoked and the request terminates.
+ * 6.  The API provider request has now passed the early checks, the request can still fail, but it is now
+ *     not an early failure and earlyFailure will now not be called.
+ * 7.  If there is an Interceptor registered at either the Global, Service or API levels that
  *     implements the Interceptor interface its preInvoke method will be invoked. This is point P1.
  * 8.  Request flow continues through z/OS Connect EE into the Service Provider which will call the
  *     System Of Record, e.g. CICS, IMS, DB2, etc.
- * 9.  If there is an Interceptor registered with either the Global, Service or API Interceptor Managers that
+ * 9.  If there is an Interceptor registered at either the Global, Service or API levels that
  *     implements the ServiceProviderInterceptor interface its preSorInvoke method will be invoked.
  *     This is point P2.  The SoR is then invoked.
  * 10. Once the SoR returns the ServiceProviderInterceptor is invoked on its postSorInvoke method.
  *     This is point P3.
- * 11. The API Provider response flow continues, any registered Interceptor's with either the Global, Service
- *     or API Interceptor Managers that implements the Interceptor interface is invoked on its postInvoke method.
+ * 11. The API provider response flow continues, any registered Interceptors at either the Global, Service or API
+ *     levels that implements the Interceptor interface is invoked on its postInvoke method.
  *     This is point P4. Finally the response is sent by z/OS Connect EE.
  *
  * This Interceptor will be notified for all requests entering the z/OS Connect EE application on the Interceptor's
@@ -79,7 +79,7 @@ public class SimpleInterceptorImpl implements Interceptor {
 
     /**
      * The registered sequence number of this Interceptor which determines the order
-     * in which the Interceptor is called in relation to other Interceptor's.
+     * in which the Interceptor is called in relation to other Interceptors.
      */
     private int sequence;
 
@@ -134,8 +134,7 @@ public class SimpleInterceptorImpl implements Interceptor {
     }
 
     /**
-     * Returns this Interceptor's configured sequence number so the Interceptor Manager
-     * can determine the call sequence of Interceptor's.
+     * Returns this Interceptor's configured sequence number.
      */
     @Override
     public int getSequence() {
@@ -151,7 +150,7 @@ public class SimpleInterceptorImpl implements Interceptor {
     }
 
     /**
-     * Interceptor Manager calls preInvoke method at point P1.
+     * z/OS Connect EE calls preInvoke method at point P1.
      *
      * The Interceptor is given a request state map that can be used to store data entities between the preInvoke
      * at P1 and the postInvoke at P4.
@@ -160,7 +159,7 @@ public class SimpleInterceptorImpl implements Interceptor {
      * URL, HTTP Headers, etc. See com.ibm.zosconnect.spi.HttpZosConnectRequest javadoc for details.
      *
      * The Data object provides the request specific data available to Interceptor's and Service Providers.
-     * See com.ibm.zosconnect.spi.Data javadoc for details.  As the API Provider request flows through
+     * See com.ibm.zosconnect.spi.Data javadoc for details.  As the API provider request flows through
      * z/OS Connect EE more data elements are captured and stored in the Data object.  As an example
      * Data.TIME_ZOS_CONNECT_ENTRY is available which contains the z/OS Store Clock Extended time held
      * in a byte array of length 16.
@@ -197,7 +196,7 @@ public class SimpleInterceptorImpl implements Interceptor {
 
         /*
          * Validate the user, if the userid starts with "EX" then this is an Example id
-         * and is not allowed to run API Provider requests.
+         * and is not allowed to run API provider requests.
          */
         if (user.startsWith("EX")) {
             /*
@@ -220,10 +219,10 @@ public class SimpleInterceptorImpl implements Interceptor {
     }
 
     /**
-     * Interceptor Manager calls postInvoke method at point P4.
+     * z/OS Connect EE calls postInvoke method at point P4.
      *
      * The Data object provides the request specific data available to Interceptor's and Service Providers.
-     * See com.ibm.zosconnect.spi.Data javadoc for details.  As the API Provider request flows through
+     * See com.ibm.zosconnect.spi.Data javadoc for details.  As the API provider request flows through
      * z/OS Connect EE more data elements are captured and stored in the Data object.
      *
      * New Data elements that are available and relevant to point P4 are:

--- a/src/com.ibm.crshnburn.zosconnect.interceptor/src/com/ibm/crshnburn/zosconnect/interceptor/SimpleInterceptorRequesterImpl.java
+++ b/src/com.ibm.crshnburn.zosconnect.interceptor/src/com/ibm/crshnburn/zosconnect/interceptor/SimpleInterceptorRequesterImpl.java
@@ -1,0 +1,189 @@
+/*
+ Copyright IBM Corporation 2020
+
+ LICENSE: Apache License
+          Version 2.0, January 2004
+          http://www.apache.org/licenses/
+
+ The following code is sample code created by IBM Corporation.
+ This sample code is not part of any standard IBM product and
+ is provided to you solely for the purpose of assisting you in
+ the development of your applications.  The code is provided
+ 'as is', without warranty or condition of any kind.  IBM shall
+ not be liable for any damages arising out of your use of the
+ sample code, even if IBM has been advised of the possibility
+ of such damages.
+*/
+package com.ibm.crshnburn.zosconnect.interceptor;
+
+import java.util.Map;
+
+import org.osgi.service.component.ComponentContext;
+
+import com.ibm.zosconnect.spi.Data;
+import com.ibm.zosconnect.spi.DataRequester;
+import com.ibm.zosconnect.spi.HttpZosConnectRequest;
+import com.ibm.zosconnect.spi.InterceptorException;
+import com.ibm.zosconnect.spi.InterceptorRequester;
+
+/**
+ * The SimpleInterceptorRequesterImpl class is an example of an Interceptor that implements only the 
+ * InterceptorRequester interface. As the InterceptorRequester interface extends the Interceptor interface, 
+ * you must also implement the methods of the Interceptor interface as well.
+ * 
+ * Note, it is possible that an Interceptor can be configured so that it is invoked more than once for the same 
+ * request, although this is unlikely to be intended behaviour.
+ * 
+ * This sample Interceptor is invoked at two points in an API requester flow, as illustrated here:
+ * https://www.ibm.com/support/knowledgecenter/SS4SVW_3.0.0/extending/requester_interceptors.html and detailed in
+ * steps 3 and 7 below.
+ *
+ * The API requester request flow:
+ * 1.  A request is received by z/OS Connect EE from the communication stub program BAQCSTUB.
+ * 2.  Authentication and request format checks are made.
+ * 3.  If there is an Interceptor registered at either the global or API requester level that implements 
+ *     the InterceptorRequester interface, its preInvokeRequester method is called. 
+ * 4.  Request data mapping is performed.
+ * 5.  The API request is sent to the endpoint.
+ * 6.  Response data mapping is performed.
+ * 7.  The InterceptorRequester postInvokeRequester method is called if the corresponding preInvokeRequester method
+ *     was called.
+ * 8. z/OS Connect EE returns the response to the BAQCSTUB program.
+ *
+ * @author IBM
+ */
+public class SimpleInterceptorRequesterImpl implements InterceptorRequester {
+
+	/**
+     * The registered sequence number of this Interceptor which determines the order
+     * in which the Interceptor is called in relation to other Interceptors.
+     */
+    private int sequence;
+    
+    /**
+     * Activates the Interceptor.
+     *
+     * Trace the activation and retrieve the Interceptor's sequence number from
+     * the Interceptor's configuration element in server.xml.
+     *
+     * @param context
+     * @param properties
+     */
+    protected void activate(ComponentContext context, Map<String, Object> properties) {
+
+        System.out.println(getName() + " activated");
+        if (properties.containsKey(CFG_AD_SEQUENCE_ALIAS)) {
+            sequence = (Integer) properties.get(CFG_AD_SEQUENCE_ALIAS);
+        }
+    }
+
+    /**
+     * Deactivates the Interceptor.
+     *
+     * The Interceptor will no longer receive events.
+     *
+     * @param context
+     */
+    protected void deactivate(ComponentContext context) {
+        System.out.println(getName() + " deactivated");
+    }
+
+    /**
+     * Called to signal that the Interceptor's configuration element may have changed in server.xml.
+     *
+     * Trace the activation and retrieve the Interceptor's sequence number from
+     * the Interceptor's configuration element in server.xml.
+     *
+     * @param context
+     * @param properties
+     */
+    protected void modified(Map<String, Object> properties) {
+
+        System.out.println(getName() + " modified");
+        if (properties.containsKey(CFG_AD_SEQUENCE_ALIAS)) {
+            sequence = (Integer) properties.get(CFG_AD_SEQUENCE_ALIAS);
+        }
+    }
+    
+    /**
+     * Returns this Interceptor's name.
+     */
+	@Override
+	public String getName() {
+		return "zOSConnectReferenceInterceptorRequester";
+	}
+
+	/**
+     * Returns this Interceptor's configured sequence number so z/OS Connect EE can 
+     * determine the sequence in which to call Interceptors.
+     */
+	@Override
+	public int getSequence() {
+		return sequence;
+	}
+
+	/**
+     * z/OS Connect EE calls the preInvokeRequester method after initial request checks.
+     *
+     * The Interceptor is given a request state map that can be used to store data, such as state data, between the 
+     * preInvokeRequester and the postInvokeRequester methods.
+     *
+     * The DataRequester object provides API requester specific data to the Interceptor.
+     * See com.ibm.zosconnect.spi.DataRequester javadoc for details. As the API requester request flows through
+     * z/OS Connect EE more data is captured and stored in the DataRequester object.  
+     *
+     * In this example, the API requester name and version are obtained and logged.
+     * 
+     * @param requestStateMap
+     * @param data
+     */
+	@Override
+	public void preInvokeRequester(Map<Object, Object> requestStateMap, DataRequester data) throws InterceptorException {
+		System.out.println(getName() + " preInvokeRequester entry ");
+		
+		System.out.println("Invoking the API requester " + data.getData(DataRequester.API_REQUESTER_NAME) + 
+		                   " verion " + data.getData(DataRequester.API_REQUESTER_VERSION));
+		
+		System.out.println(getName() + " preInvokeRequester exit");
+	}
+	
+	/**
+	 * z/OS Connect EE calls the postInvokeRequester method.
+     *
+     * The DataRequester object provides API requester specific data to the Interceptor.
+     * See com.ibm.zosconnect.spi.DataRequester javadoc for details.  
+     * 
+     * In this example, the request response code is obtained and logged.
+     *
+     * @param requestStateMap
+     * @param data
+     */
+	@Override
+	public void postInvokeRequester(Map<Object, Object> requestStateMap, DataRequester data) throws InterceptorException {
+		System.out.println(getName() + " postInvokeRequester entry");
+		
+		System.out.println("API requester returning to calling application with " + data.getData(DataRequester.REQUEST_STATUS_CODE));
+		
+		System.out.println(getName() + " postInvokeRequester exit");
+	}
+	
+	/**
+     * This method is not called for API requester requests. It is called for API provider and all administration requests.
+     */
+	@Override
+	public void preInvoke(Map<Object, Object> requestStateMap, HttpZosConnectRequest request, Data data) throws InterceptorException {
+		System.out.println(getName() + " preInvoke");
+		System.out.println(getName() + " preInvoke exit");
+	}
+	
+	/**
+     * This method is not called for API requester requests. It is called for API provider and all administration requests.
+     */
+	@Override
+	public void postInvoke(Map<Object, Object> requestStateMap, HttpZosConnectRequest request, Data data)
+			throws InterceptorException {
+		System.out.println(getName() + " postInvoke");
+		System.out.println(getName() + " postInvoke exit");
+	}
+	
+}


### PR DESCRIPTION
Two new samples for the API requester interceptors, added in z/OS Connect EE 3.0.39, are now provided. The sample interceptor project is also updated to compile with Java 1.8.